### PR TITLE
fix: 훈련 데이터 로직 수정

### DIFF
--- a/common_mbti_prediction.py
+++ b/common_mbti_prediction.py
@@ -8,7 +8,6 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from joblib import dump, load
 import os
 
-# 전체 데이터셋 중 0.1 %만 데려와서 사용
 mbti = pd.read_csv('./csv/MBTI_sample.csv')
 
 def train_model():
@@ -59,23 +58,28 @@ def make_common_feedback_df(user_answer: str, user_mbti: str):
     feedback_df.to_csv('./feedback/common/common_feedback.csv')
     
 def extra_train_model():
-    feedback_df = pd.read_csv('./feedback/common/common_feedback.csv')
-    
-    if len(feedback_df) >= 3:
-        X = feedback_df['posts']
-        y = feedback_df['type']
+    if os.path.exists('./feedback/common/common_feedback.csv'):
+        feedback_df = pd.read_csv('./feedback/common/common_feedback.csv')
         
-        vectorizer = load('./models/vectorizer_text_re.joblib')
-        train_tfidf = vectorizer.fit_transform(X)
-    
-        grid_search = load('./models/model_common_mbti_all.joblib')
-        grid_search.fit(train_tfidf, y)
-    
-        dump(vectorizer, './models/vectorizer_text_re.joblib')
-        dump(grid_search, './models/model_common_mbti_all.joblib')
+        if len(feedback_df) >= 5:
+            X = feedback_df['posts']
+            y = feedback_df['type']
+            
+            vectorizer = load('./models/vectorizer_text_re.joblib')
+            train_tfidf = vectorizer.fit_transform(X)
+        
+            grid_search = load('./models/model_common_mbti_all.joblib')
+            grid_search.fit(train_tfidf, y)
+        
+            dump(vectorizer, './models/vectorizer_text_re.joblib')
+            dump(grid_search, './models/model_common_mbti_all.joblib')
+            
+            return True, len(feedback_df)
+        else:
+            return False, len(feedback_df)
     
     else:
-        return False
+        return False, 0
 
 def mbti_prediction(answer: str):
     vectorizer = load('./models/vectorizer_text_re.joblib')
@@ -93,11 +97,3 @@ def get_common_mbti(answer: str):
     kr_answer = get_translate(answer)
     mbti = mbti_prediction(kr_answer)
     return mbti
-
-def train_model(user_mbti: str, answer: str):
-    is_success = extra_train_model(answer, user_mbti)
-    
-    if is_success:
-        return True
-    else:
-        return False

--- a/main.py
+++ b/main.py
@@ -43,6 +43,9 @@ class Feedback(BaseModel):
     mbti: str
     common_answer: str
     detail_answer: List[DetailAnswer]
+    
+class TrainType(BaseModel):
+    mbti_type: str # ['IE', 'SN', 'FT', 'PJ']
 
 @app.post("/answer/common")
 def get_common_answer(user_answer: Answer):
@@ -129,27 +132,33 @@ def get_feedback(feedback: Feedback):
                 }
             }
         )
-        
+
 @app.post('/train')
-def extra_train():
+def extra_train(train_type: TrainType):
     try:
-        common_is_successed = extra_train_model()
-        detail_is_successed = extra_train_specific_model()
+        common_is_successed, common_counts = extra_train_model()
+        detail_is_successed, detail_counts = extra_train_specific_model(train_type.mbti_type)
 
         if not common_is_successed:
             return JSONResponse(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 content={
+                    "statusCode": 422,
                     "data": {
-                        "message": [ '일반 질문 피드백 데이터가 적어 아직 훈련할 수 없습니다.']
+                        "message": [ '일반 질문 피드백 데이터가 적어 아직 훈련할 수 없습니다.'],
+                        "dataLength": common_counts
                     }
                 }
             )
-        
+ 
         if not detail_is_successed:
             return JSONResponse(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 content={
+                    "statusCode": 422,
                     "data": {
-                        "message": [ '세부 질문 피드백 데이터가 적어 아직 훈련할 수 없습니다.']
+                        "message": [ '세부 질문 피드백 데이터가 적어 아직 훈련할 수 없습니다.'],
+                        "dataLength": detail_counts
                     }
                 }
             )

--- a/specific_mbti_prediction.py
+++ b/specific_mbti_prediction.py
@@ -22,7 +22,7 @@ def mbti_train_and_prediction(mbti_type: str, answer: str):
     
     vectorizer = TfidfVectorizer()
     X_train_tfidf = vectorizer.fit_transform(X)
-    joblib.dump(vectorizer, './models/vectorizer_detail_text.sav')
+    joblib.dump(vectorizer, './models/vectorizer_detail_text.joblib')
 
     X_test = answer
 
@@ -59,23 +59,28 @@ def make_detail_feedback_df(user_feedback):
             
         feedback_df.to_csv('./feedback/detail/detail_feedback_{0}.csv'.format(mbti_name[mbti]))
 
-def extra_train_specific_model():
-    mbti_type = ['IE', 'SN', 'FT', 'PJ']
+def extra_train_specific_model(mbti_type: str):
     
-    for m in mbti_type:
-        feedback_df = pd.read_csv('./feedback/detail/detail_feedback_{0}.csv'.format(m))
-    
+    if os.path.exists('./feedback/detail/detail_feedback_{0}.csv'.format(mbti_type)):
+        feedback_df = pd.read_csv('./feedback/detail/detail_feedback_{0}.csv'.format(mbti_type))
+        
         if len(feedback_df) >= 3:
             X = feedback_df['word']
             y = feedback_df['mbti']
         
-            vectorizer = joblib.load('./models/vectorizer_detail_text.sav')
-            clf = pickle.load(open('./models/model_detail_mbti_{0}.sav'.format(m), 'rb'))
+            vectorizer = joblib.load('./models/vectorizer_detail_text.joblib')
+            clf = pickle.load(open('./models/model_detail_mbti_{0}.sav'.format(mbti_type), 'rb'))
         
             X_train_tfidf = vectorizer.fit_transform(X)
             clf.fit(X_train_tfidf, y)
         
             joblib.dump(vectorizer, './models/vectorizer_detail_text.joblib')
-            pickle.dump(clf, open('./models/model_detail_mbti_{0}.sav'.format(m)), 'wb')
+            pickle.dump(clf, open('./models/model_detail_mbti_{0}.sav'.format(mbti_type), 'wb'))
+            
+            return True, len(feedback_df)
         else:
-            return False
+            return False, len(feedback_df)
+    
+    else:
+        return False, 0
+    


### PR DESCRIPTION
- 훈련을 진행하지 못할 만큼의 데이터 양을 가진 경우, 데이터의 개수를 반환하고 422번 예외처리하도록 수정
- 세부질문에 대한 추가 훈련을 진행할 때, mbti 타입을 입력받아 해당 타입에 대해서만 추가 훈련을 진행하도록 수정
- 세부질문에 대한 추가 훈련을 진행할 때, 해당 mbti 타입과 관련된 피드백 데이터 파일의 존재 여부 확인